### PR TITLE
chore(release): bump version to 1.2.1 (DEV-1340)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publisher": "fliplet",
 	"displayName": "Fliplet Developer Tools",
 	"description": "Manage code for your Fliplet Apps via Visual Studio Code",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"engines": {
 		"vscode": "^1.51.0"
 	},


### PR DESCRIPTION
Bumps version from 1.2.0 to 1.2.1 to trigger a marketplace release with the DEV-1340 auth fix.

The last marketplace publish was September 2024 (v1.2.0). Users reinstalling the extension from the marketplace still get the broken version. This version bump, once merged and published via `vsce publish`, will push the fixed build to the marketplace.

Changes included in this release (from master):
- Fix broken sign-in: replace removed `/v1/auth/third-party` with `/v1/auth/login?return=callback`
- Null-token guard with user-facing error message
- Restore `source=VSCode` session tagging
- Rebuilt `dist/extension.js`