### PR TITLE
chore: exclude .claude/ and node_modules/ from VSIX bundle

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,3 +9,5 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
+.claude/
+node_modules/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publisher": "fliplet",
 	"displayName": "Fliplet Developer Tools",
 	"description": "Manage code for your Fliplet Apps via Visual Studio Code",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"engines": {
 		"vscode": "^1.51.0"
 	},


### PR DESCRIPTION
## Summary
- Added `.claude/` and `node_modules/` to `.vscodeignore` to prevent local dev files from being included in the VSIX when publishing to the VS Code Marketplace

## Test plan
- [ ] Run `vsce package` and confirm neither `.claude/` nor `node_modules/` appear in the listed VSIX contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)